### PR TITLE
Fix: Install `Test::Without::Module@0.20` perl module in `ubuntu` `geoip2` variants to fix builds failing randomly (continued)

### DIFF
--- a/generate/templates/Dockerfile/ubuntu/geoip2/geoip2.ps1
+++ b/generate/templates/Dockerfile/ubuntu/geoip2/geoip2.ps1
@@ -10,10 +10,11 @@ RUN set -eux \
         #libio-socket-ssl-perl \
         #libwww-perl \
         #libdatetime-perl \
+    # Install older version of Test::Without::Module, since Test::Without::Module@0.21 seems to fail tests randomly. See: https://metacpan.org/release/CORION/Test-Without-Module-0.21
+    && cpanm \
+        Test::Without::Module@0.20 \
     && cpanm \
         MaxMind::DB::Reader \
-        # Test-Without-Module-0.21 seems to fail tests randomly. See: https://metacpan.org/release/CORION/Test-Without-Module-0.21
-        Test::Without::Module@0.20 \
     && cpanm \
         GeoIP2 \
 # Install maxmind DB::Reader::XS (faster than MaxMind::DB::Reader)

--- a/variants/v1.6.19-geoip-geoip2-emailsender-ubuntu-16.04/Dockerfile
+++ b/variants/v1.6.19-geoip-geoip2-emailsender-ubuntu-16.04/Dockerfile
@@ -98,10 +98,11 @@ RUN set -eux \
         #libio-socket-ssl-perl \
         #libwww-perl \
         #libdatetime-perl \
+    # Install older version of Test::Without::Module, since Test::Without::Module@0.21 seems to fail tests randomly. See: https://metacpan.org/release/CORION/Test-Without-Module-0.21
+    && cpanm \
+        Test::Without::Module@0.20 \
     && cpanm \
         MaxMind::DB::Reader \
-        # Test-Without-Module-0.21 seems to fail tests randomly. See: https://metacpan.org/release/CORION/Test-Without-Module-0.21
-        Test::Without::Module@0.20 \
     && cpanm \
         GeoIP2 \
 # Install maxmind DB::Reader::XS (faster than MaxMind::DB::Reader)

--- a/variants/v1.6.19-geoip-geoip2-ubuntu-16.04/Dockerfile
+++ b/variants/v1.6.19-geoip-geoip2-ubuntu-16.04/Dockerfile
@@ -98,10 +98,11 @@ RUN set -eux \
         #libio-socket-ssl-perl \
         #libwww-perl \
         #libdatetime-perl \
+    # Install older version of Test::Without::Module, since Test::Without::Module@0.21 seems to fail tests randomly. See: https://metacpan.org/release/CORION/Test-Without-Module-0.21
+    && cpanm \
+        Test::Without::Module@0.20 \
     && cpanm \
         MaxMind::DB::Reader \
-        # Test-Without-Module-0.21 seems to fail tests randomly. See: https://metacpan.org/release/CORION/Test-Without-Module-0.21
-        Test::Without::Module@0.20 \
     && cpanm \
         GeoIP2 \
 # Install maxmind DB::Reader::XS (faster than MaxMind::DB::Reader)


### PR DESCRIPTION
Continuation of #17
